### PR TITLE
Add a shorter check in isSimpler check after indirect check

### DIFF
--- a/src/mine/checker.cpp
+++ b/src/mine/checker.cpp
@@ -64,7 +64,7 @@ bool isSimpler(const Program& existing, const Program& optimized) {
   if (hasIndirectOperand(existing) && !hasIndirectOperand(optimized)) {
     return true;
   }
-  return false;
+  return optimized.ops.size() <= existing.ops.size()/2 && !optimized_has_seq;
 }
 
 // Return true if all constants used in the program are within [-100,100]


### PR DESCRIPTION
Add a shorter check in `isSimpler` check after indirect check. If a program's length <= half of existing program length, it will be considered simpler.